### PR TITLE
Update App.cpp

### DIFF
--- a/source/App.cpp
+++ b/source/App.cpp
@@ -119,7 +119,7 @@ int sdliv::App::OnExecute()
 
 	SDL_AddEventWatch([](void * appV, SDL_Event *event)-> int
 	{
-		if (event->type == SDL_WINDOWEVENT && event->window.type == SDL_WINDOWEVENT_SIZE_CHANGED)
+		if (event->type == SDL_WINDOWEVENT)
 		{
 			sdliv::App *app = (sdliv::App*)appV;
 			app->window->centerElement(app->active_element);


### PR DESCRIPTION
undo change to window event filter, some window event change the size of a window without issueing a size changed event (e.g. maximize).