### PR TITLE
SDL2 Update for Windows

### DIFF
--- a/include/sdliv.h
+++ b/include/sdliv.h
@@ -10,10 +10,9 @@
 
 //windows
 #else
-#include <sdl2.2.0.5\build\native\include\SDL.h>
-#include <sdl2_image.v140.2.0.1\build\native\include\SDL_image.h>
+#include <sdl2.nuget.2.0.12\build\native\include\SDL.h>
+#include <sdl2_image.nuget.2.0.5\build\native\include\SDL_image.h>
 #include <sdl2_ttf.v140.2.0.14\build\native\include\SDL_ttf.h>
-#define NO_INIT_SVG
 #endif
 
 #include <map>

--- a/source/Element.cpp
+++ b/source/Element.cpp
@@ -1,9 +1,3 @@
-#ifndef WIN32
-#include <SDL2/SDL.h>
-#else
-#include <sdl2.2.0.5\build\native\include\SDL.h>
-#endif
-
 #include <sdliv.h>
 
 

--- a/source/FileHandler.cpp
+++ b/source/FileHandler.cpp
@@ -17,9 +17,7 @@ std::set<std::string> sdliv::FileHandler::supportedExtensions = {
 	".lbm",
 	".pcx",
 	".pnm",
-#ifndef NO_INIT_SVG
 	".svg",
-#endif
 	".xcf",
 	".xpm",
 	".xv",
@@ -413,9 +411,7 @@ sdliv::ImageFileType sdliv::FileHandler::detectImageType()
 	else if (IMG_isGIF(rwops))  { type = FILETYPE_GIF; }
 	else if (IMG_isWEBP(rwops)) { type = FILETYPE_WEBP; }
 	else if (IMG_isTIF(rwops))  { type = FILETYPE_TIF; }
-#ifndef NO_INIT_SVG
 	else if (IMG_isSVG(rwops))  { type = FILETYPE_SVG; }
-#endif
 	else if (IMG_isICO(rwops))  { type = FILETYPE_ICO; }
 	else if (IMG_isCUR(rwops))  { type = FILETYPE_CUR; }
 	else if (IMG_isLBM(rwops))  { type = FILETYPE_LBM; }


### PR DESCRIPTION
Upgraded SDL2 & SDL2_Image which adds SVG support. Removed SVG #define guards.